### PR TITLE
[Issue #1] Create action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI - Test auto-close action
+
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  lint-test:
+    name: Run auto-close issues
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN_PROJECT_ACCESS }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          owner: widal001
+          owner-type: user
+          project-number: "3"
+          status: "✅ Done"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore a temporary directory for script outputs
+tmp/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# auto-close-issues
-GitHub action to auto-close issues that are marked as "Done" in a GitHub project
+# Auto-close issues that are "Done"
+
+Automatically close issues that are marked as "Done" in a GitHub project but still open in the repo.
+
+### Quickstart
+
+Create a Personal Access Token (PAT) with the following privileges:
+
+- `public_repo` 
+- `read:project`
+- `read:org` (Only required for projects owned by organizations)
+
+Add that token to your repository secrets with the name `GITHUB_TOKEN_PROJECT_ACCESS` or a similar name.
+
+Create a GitHub action file in `.github/workflows/` with the following code:
+
+```yaml
+name: Close done issues
+
+on:
+  # Enables manual triggers of this action
+  workflow_dispatch:
+  # Runs this action every Monday-Friday at 5am UTC
+  schedule:
+    - cron: "00 5 * * 1-5"
+
+jobs:
+  auto-close-issues:
+    name: Auto-close issues that are done
+    runs-on: ubuntu-latest
+    env:
+      # Gives the gh CLI access to your project
+      GH_TOKEN: ${{ secrets.GH_TOKEN_PROJECT_ACCESS }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: widal001/auto-close-issues@v1
+        with:
+          owner: widal001
+          owner-type: user
+          project-number: "3"
+          status: "✅ Done"
+          # optionally control number of project items returned per API call
+          # must be less than or equal 100 due to GitHub limits
+          batch-size: "100"
+```

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,39 @@
+name: "Auto-close issues"
+description: "Automatically close issues that are marked as 'Done' in a project but still open"
+inputs:
+  owner:
+    description: "The owner of the project"
+    required: true
+  owner-type:
+    description: "Is the project owner an organization or a user?"
+    required: false
+    default: "organization"
+  project-number:
+    description: "The number of the project"
+    required: true
+  status:
+    description: "Which status indicates an issue is 'Done'?"
+    required: true
+  batch-size:
+    description: "The number of project items to return per API call"
+    required: false
+    default: "100"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Close issues
+      run: |
+        ./close-done-issues.sh \
+          --owner "${OWNER}" \
+          --owner-type "${OWNER_TYPE}" \
+          --project $PROJECT \
+          --status "${STATUS}" \
+          --batch $BATCH
+      shell: bash
+      env:
+        OWNER: ${{ inputs.owner }}
+        OWNER_TYPE: ${{ inputs.owner-type }}
+        PROJECT: ${{ inputs.project-number }}
+        STATUS: ${{ inputs.status }}
+        BATCH: ${{ inputs.batch-size }}

--- a/close-done-issues.sh
+++ b/close-done-issues.sh
@@ -1,0 +1,125 @@
+#! /bin/bash
+# Usage: ./close-done-issues.sh \
+#  --batch 100
+#  --org widal001 
+#  --project 3
+#  --project-type "user"
+#  --status "Done"
+#  --dry-run # optionally print items to close before actually closing them
+# Closes issues that are in the "Done" column on a project but still open in the repo
+
+# parse command line args with format `--option arg`
+# see this stack overflow for more details:
+# https://stackoverflow.com/a/14203146/7338319
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      echo "Running in dry run mode"
+      dry_run=YES
+      shift # past argument
+      ;;
+    --batch)
+      batch="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --owner)
+      login="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --owner-type)
+      owner_type="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --project)
+      project="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --status)
+      status="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      positional_args+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+
+# Create a function to check that required variables are set
+check_vars()
+{
+  # for each variable passed as an argument
+  # if a variable is unset, then print it to the console
+  var_names=("$@")
+  for var_name in "${var_names[@]}"; do
+      [ -z "${!var_name}" ] && echo "$var_name is unset." && var_unset=true
+  done
+  # if at least one variable is unset exit with a non-zero status
+  [ -n "$var_unset" ] && exit 1
+}
+
+# check that required variables were passed as flags
+check_vars batch login project status
+
+# set the login-specific variables
+if [[ $owner_type == "organization" ]]; then
+  is_org="true"
+  owner_prefix="orgs"
+elif [[ $owner_type == "user" ]]; then
+  is_org="false"
+  owner_prefix="users"
+else
+  echo "--project-type must be one of 'organization' or 'user', not ${owner_type}"
+  exit 1
+fi
+
+# set script-specific variables
+mkdir -p tmp
+to_close_file="./tmp/open-issues-that-are-done.txt"
+query=$(cat ./get-project-data.graphql)
+
+# print the parsed variables for debugging
+echo "Finding open issues in the '${status}' column of GitHub project: ${login}/${project}"
+
+# get all tickets from the project with:
+# URL, open/closed state in the repo, and status on the project
+gh api graphql \
+ --paginate \
+ --field login="${login}" \
+ --field project="${project}" \
+ --field batch="${batch}" \
+ --field isOrgProject="${is_org}" \
+ -f query="${query}" \
+ --jq ".data.${owner_type}.projectV2.items.nodes" |\
+ # combine results into a single array
+ jq --slurp 'add' |\
+ # isolate the URLs of the issues that are marked "Done" in the project
+ # but still open in the repo, and use --raw-ouput flag to remove quotes
+ jq --raw-output "
+ .[]
+ | select((.status.name == \"${status}\") and (.issue.state == \"OPEN\"))
+ | .issue.url" > $to_close_file  # write output to a file
+
+# iterate through the list of URLs written to the to_close_file
+# and close them with a comment indicating the reason for closing
+comment="Beep boop: Automatically closing this issue because it was marked as '${status}' "
+comment+="in https://github.com/${owner_prefix}/${login}/projects/${project}. "
+comment+="This action was performed by a bot."
+while read url; do
+  if [[ $dry_run == "YES" ]];
+  then
+    echo "Would close issue with URL: ${url}"
+  else
+    echo "Closing issue with URL: ${url}"
+    gh issue close $url --comment "${comment}"
+  fi
+done < $to_close_file

--- a/close-done-issues.sh
+++ b/close-done-issues.sh
@@ -88,7 +88,7 @@ to_close_file="./tmp/open-issues-that-are-done.txt"
 query=$(cat ./get-project-data.graphql)
 
 # print the parsed variables for debugging
-echo "Finding open issues in the '${status}' column of GitHub project: ${login}/${project}"
+echo "Finding open issues in the '${status}' column of https://github.com/${owner_prefix}/${login}/projects/${project}"
 
 # get all tickets from the project with:
 # URL, open/closed state in the repo, and status on the project

--- a/get-project-data.graphql
+++ b/get-project-data.graphql
@@ -1,0 +1,51 @@
+query (
+  $endCursor: String
+  $login: String!
+  $project: Int!
+  $batch: Int!
+  $isOrgProject: Boolean!
+) {
+  # get the project by the organization's login and project number
+  organization(login: $login) @include(if: $isOrgProject) {
+    projectV2(number: $project) {
+      # insert the projectFields fragment below
+      ...projectFields
+    }
+  }
+  # get the project by the user's login
+  user(login: $login) @skip(if: $isOrgProject) {
+    projectV2(number: $project) {
+      # insert the projectFields fragment below
+      ...projectFields
+    }
+  }
+}
+
+fragment projectFields on ProjectV2 {
+  # get project items in batches of 100, which is the match batch size
+  items(first: $batch, after: $endCursor) {
+    # allows us to use --paginate in the gh api call
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+
+    # fetch details per item in the list
+    nodes {
+      # fetch the value of the status column
+      status: fieldValueByName(name: "Status") {
+        ... on ProjectV2ItemFieldSingleSelectValue {
+          name
+        }
+      }
+
+      # fetch the issue URL and open/closed state
+      issue: content {
+        ... on Issue {
+          url
+          state
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Creates a new custom GitHub action that auto-closes issues that are marked as "Done" in a GitHub project but still open.

- Fixes: #1 
- Time to review: 5 minutes

### Changes proposed

- Adds `close-done-issues.sh` which auto-closes issues that are done
- Adds `get-project-data.graphql` which fetches project data to find issues that are done
- Adds `action.yaml` which outlines the metadata for this custom action
- Adds `ci.yaml` which tests the custom GitHub action as part of the CI pipeline
- Adds README explaining how to use the custom action

### Context for reviewers

You can see how this custom action works by checking the run from the [CI task associated with this PR](https://github.com/widal001/auto-close-issues/actions/runs/9040010436/job/24843651151)

